### PR TITLE
Potential fix for code scanning alert no. 2: Bad HTML filtering regexp

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,8 @@
     "tailwind-merge": "^2.5.2",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^0.9.3",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "dompurify": "^3.2.6"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.0",

--- a/src/components/forms/ContactForm.tsx
+++ b/src/components/forms/ContactForm.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import DOMPurify from 'dompurify';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
@@ -13,11 +14,9 @@ import { toast } from 'sonner';
 
 // Input sanitization function
 const sanitizeInput = (input: string): string => {
-  return input
-    .replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '')
-    .replace(/<[^>]*>/g, '')
-    .trim()
-    .slice(0, 1000); // Limit length
+  // Purifies input by stripping all HTML tags and scripts safely.
+  const purified = DOMPurify.sanitize(input, { ALLOWED_TAGS: [] });
+  return purified.trim().slice(0, 1000); // Limit length
 };
 
 const contactFormSchema = z.object({


### PR DESCRIPTION
Potential fix for [https://github.com/chiproy999/opendoors-tulsa-blank/security/code-scanning/2](https://github.com/chiproy999/opendoors-tulsa-blank/security/code-scanning/2)

To guarantee safe input sanitization and avoid XSS vulnerabilities, replace the custom `sanitizeInput` function (lines 15-21) with a well-tested HTML sanitizer, such as `dompurify`. `dompurify` correctly removes dangerous markup according to browser parsing rules and is commonly used in React projects. 
- Install the package `dompurify`.
- At the top of the file, import `DOMPurify`.
- Replace the custom `sanitizeInput` implementation with one that uses `DOMPurify.sanitize`, followed by a length check and trim.
- Ensure that the sanitization function strips out all HTML tags and scripts. For this, you can pass `{ALLOWED_TAGS: []}` to `DOMPurify.sanitize` which removes all tags, leaving only text content.

Edits will be made only to `src/components/forms/ContactForm.tsx`: 
- Add import for `dompurify`.
- Replace `sanitizeInput` function implementation.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
